### PR TITLE
feat: get default driver from *viper.Viper

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,25 +13,29 @@ import (
 const File = ".goss.yml"
 
 // ReadInConfig Load the configuration file from the specified path.
-func ReadInConfig(path string) error {
+func ReadInConfig(path string) (*viper.Viper, error) {
 	exist, err := fs.Exists(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !exist {
-		return fmt.Errorf("Configuration file not exists：%s\n", path)
+		return nil, fmt.Errorf("Configuration file not exists：%s\n", path)
 	}
 
-	viper.SetConfigFile(path)
+	v := viper.New()
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
 
-	return viper.ReadInConfig()
+	return v, nil
 }
 
 // ReadInUserHomeConfig Load the configuration file from user home directory.
-func ReadInUserHomeConfig() error {
+func ReadInUserHomeConfig() (*viper.Viper, error) {
 	path, err := UserHomeConfigPath()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return ReadInConfig(path)

--- a/drivers/aliyun/aliyun_test.go
+++ b/drivers/aliyun/aliyun_test.go
@@ -11,8 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/spf13/viper"
-
 	config2 "github.com/eleven26/goss/config"
 	"github.com/eleven26/goss/core"
 	"github.com/eleven26/goss/utils"
@@ -34,12 +32,12 @@ var (
 )
 
 func init() {
-	err := config2.ReadInUserHomeConfig()
+	vip, err := config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	d := NewDriver(core.WithViper(viper.GetViper()))
+	d := NewDriver(core.WithViper(vip))
 	storage, err = d.Storage()
 	if err != nil {
 		log.Fatal(err)

--- a/drivers/huawei/huawei_test.go
+++ b/drivers/huawei/huawei_test.go
@@ -11,8 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/spf13/viper"
-
 	fs "github.com/eleven26/go-filesystem"
 	config2 "github.com/eleven26/goss/config"
 	"github.com/eleven26/goss/core"
@@ -38,12 +36,10 @@ var (
 func init() {
 	var err error
 
-	err = config2.ReadInUserHomeConfig()
+	vip, err = config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	vip := viper.GetViper()
 
 	d := NewDriver(core.WithViper(vip))
 	storage, err = d.Storage()

--- a/drivers/huawei/huawei_test.go
+++ b/drivers/huawei/huawei_test.go
@@ -36,7 +36,7 @@ var (
 func init() {
 	var err error
 
-	vip, err = config2.ReadInUserHomeConfig()
+	vip, err := config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/drivers/minio/minio_test.go
+++ b/drivers/minio/minio_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/minio/minio-go/v7"
 
 	config2 "github.com/eleven26/goss/config"
@@ -38,12 +36,10 @@ var (
 )
 
 func init() {
-	err := config2.ReadInUserHomeConfig()
+	vip, err := config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	vip := viper.GetViper()
 
 	d := NewDriver(core.WithViper(vip))
 	storage2, err = d.Storage()

--- a/drivers/qiniu/qiniu_test.go
+++ b/drivers/qiniu/qiniu_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
-
 	config2 "github.com/eleven26/goss/config"
 	"github.com/eleven26/goss/core"
 	"github.com/eleven26/goss/utils"
@@ -35,14 +33,12 @@ var (
 )
 
 func init() {
-	err := config2.ReadInUserHomeConfig()
+	vip, err := config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	v := viper.GetViper()
-
-	d := NewDriver(core.WithViper(v))
+	d := NewDriver(core.WithViper(vip))
 	storage2, err = d.Storage()
 	if err != nil {
 		log.Fatal(err)

--- a/drivers/s3/s3_test.go
+++ b/drivers/s3/s3_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	config2 "github.com/eleven26/goss/config"
@@ -37,12 +35,10 @@ var (
 )
 
 func init() {
-	err := config2.ReadInUserHomeConfig()
+	vip, err := config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	vip := viper.GetViper()
 
 	d := NewDriver(core.WithViper(vip))
 	storage2, err = d.Storage()

--- a/drivers/tencent/tencent_test.go
+++ b/drivers/tencent/tencent_test.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
-
 	config2 "github.com/eleven26/goss/config"
 	"github.com/eleven26/goss/core"
 	"github.com/eleven26/goss/utils"
@@ -34,12 +32,10 @@ var (
 )
 
 func init() {
-	err := config2.ReadInUserHomeConfig()
+	vip, err := config2.ReadInUserHomeConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	vip := viper.GetViper()
 
 	d := NewDriver(core.WithViper(vip))
 	storage, err = d.Storage()

--- a/goss/driver.go
+++ b/goss/driver.go
@@ -3,8 +3,6 @@ package goss
 import (
 	"errors"
 
-	"github.com/spf13/viper"
-
 	"github.com/eleven26/goss/core"
 	"github.com/eleven26/goss/drivers/aliyun"
 	"github.com/eleven26/goss/drivers/huawei"
@@ -32,13 +30,7 @@ var (
 )
 
 // defaultDriver get the driver specified by "driver" in the configuration file.
-func defaultDriver(opts ...core.Option) (core.Driver, error) {
-	if !viper.IsSet("driver") {
-		return nil, ErrNoDefaultDriver
-	}
-
-	driver := viper.GetString("driver")
-
+func defaultDriver(driver string, opts ...core.Option) (core.Driver, error) {
 	switch driver {
 	case Aliyun:
 		return aliyun.NewDriver(opts...), nil

--- a/goss/goss.go
+++ b/goss/goss.go
@@ -16,7 +16,7 @@ type Goss struct {
 
 // New creates a new instance based on the configuration file pointed to by configPath.
 func New(configPath string) (*Goss, error) {
-	err := config.ReadInConfig(configPath)
+	v, err := config.ReadInConfig(configPath)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func New(configPath string) (*Goss, error) {
 		core.New(),
 	}
 
-	driver, err := defaultDriver(core.WithViper(viper.GetViper()))
+	driver, err := defaultDriver(viper.GetString("driver"), core.WithViper(v))
 	if err != nil {
 		return nil, err
 	}
@@ -44,12 +44,12 @@ func New(configPath string) (*Goss, error) {
 }
 
 // NewWithViper creates a new instance based on the configuration file pointed to by viper.
-func NewWithViper(viper *viper.Viper) (*Goss, error) {
+func NewWithViper(v *viper.Viper) (*Goss, error) {
 	goss := Goss{
 		core.New(),
 	}
 
-	driver, err := defaultDriver(core.WithViper(viper))
+	driver, err := defaultDriver(v.GetString("driver"), core.WithViper(v))
 	if err != nil {
 		return nil, err
 	}

--- a/goss/goss_test.go
+++ b/goss/goss_test.go
@@ -64,7 +64,7 @@ func TestNewWithViper(t *testing.T) {
 	configPath, err = config.UserHomeConfigPath()
 	assert.Nil(t, err)
 
-	v, err = config.ReadInConfig(configPath)
+    v, err := config.ReadInConfig(configPath)
 	assert.Nil(t, err)
 
 	v.Set("driver", Aliyun)

--- a/goss/goss_test.go
+++ b/goss/goss_test.go
@@ -64,10 +64,8 @@ func TestNewWithViper(t *testing.T) {
 	configPath, err = config.UserHomeConfigPath()
 	assert.Nil(t, err)
 
-	err = config.ReadInConfig(configPath)
+	v, err = config.ReadInConfig(configPath)
 	assert.Nil(t, err)
-
-	v := viper.GetViper()
 
 	v.Set("driver", Aliyun)
 	goss, err = NewWithViper(v)


### PR DESCRIPTION
```driver := viper.GetString("driver")```  没有办法 获取*viper.Viper对象的值(现在用consul做配置管理), 
```defaultDriver(driver string, opts ...core.Option)``` 这么写又感觉不是很优雅